### PR TITLE
Added postgres solution

### DIFF
--- a/languages/postgres/Rakefile
+++ b/languages/postgres/Rakefile
@@ -1,0 +1,17 @@
+namespace :postgres do
+  task :check do
+    `which ruby`
+    raise "Please ensure that you have ruby installed" unless $?.success?
+
+    `which psql`
+    raise "Please ensure that you have psql installed" unless $?.success?
+  end
+
+  task :build => :check do
+    `createdb unscramble`
+    `psql -d unscramble -f ./languages/postgres/setup-database.sql`
+
+    puts "Indexing dictionary, this may take awhile..."
+    load "./languages/postgres/store.rb"
+  end
+end

--- a/languages/postgres/setup-database.sql
+++ b/languages/postgres/setup-database.sql
@@ -1,0 +1,95 @@
+CREATE TABLE nodes (
+   id SERIAL PRIMARY KEY,
+   letter CHAR (1) NOT NULL,
+   word VARCHAR (100),
+   parent_node_id INTEGER
+);
+
+CREATE INDEX parent_node_index ON nodes (parent_node_id);
+
+CREATE FUNCTION alphaSort (TEXT) RETURNS TEXT AS $$
+  SELECT string_agg(c, '') as s
+    FROM (
+      SELECT unnest(regexp_split_to_array($1, '')) as c
+        ORDER BY c
+      )
+    AS t;
+$$ LANGUAGE SQL IMMUTABLE;
+
+CREATE FUNCTION unscramble (VARCHAR) RETURNS VARCHAR AS $$
+  DECLARE
+    input ALIAS FOR $1;
+    output VARCHAR = '';
+
+    index INTEGER = 1;
+    currentLetter VARCHAR;
+    parentNodeId INTEGER;
+
+  BEGIN
+    -- Sort input thanks to magic function above
+    SELECT alphaSort(input)
+      INTO input;
+    currentLetter = substring(input, index, 1);
+
+    -- Loop through letters, descending down node tree
+    WHILE char_length(currentLetter) = 1 LOOP
+      IF parentNodeId IS NULL THEN
+        SELECT id
+          INTO parentNodeId
+          FROM nodes
+          WHERE letter = currentLetter
+          AND parent_node_id IS NULL;
+      ELSE
+        SELECT id
+          INTO parentNodeId
+          FROM nodes
+          WHERE letter = currentLetter
+          AND parent_node_id = parentNodeId;
+      END IF;
+
+      index = index + 1;
+      currentLetter = substring(input, index, 1);
+    END LOOP;
+
+    -- Find word based on last letter node found
+    SELECT word
+      INTO output
+      FROM nodes
+      WHERE id = parentNodeId;
+
+    RETURN output;
+  END;
+  $$ LANGUAGE plpgsql;
+
+CREATE FUNCTION findOrCreate (CHAR, INTEGER) RETURNS INTEGER AS $$
+  DECLARE
+    inputLetter ALIAS FOR $1;
+    inputId     ALIAS FOR $2;
+
+    outputId INTEGER;
+  BEGIN
+    IF inputId IS NULL THEN
+      SELECT id
+        INTO outputId
+        FROM nodes
+        WHERE
+          letter = $1 AND
+          parent_node_id IS NULL;
+    ELSE
+      SELECT id
+        INTO outputId
+        FROM nodes
+        WHERE
+          letter = $1 AND
+          parent_node_id = $2;
+    END IF;
+
+    IF outputId IS NULL THEN
+      INSERT INTO nodes (letter, parent_node_id)
+        VALUES (inputLetter, inputId)
+        RETURNING id INTO outputId;
+    END IF;
+
+    RETURN outputId;
+  END;
+  $$ LANGUAGE plpgsql;

--- a/languages/postgres/store.rb
+++ b/languages/postgres/store.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require 'pg'
+
+@db = PG.connect(dbname: 'unscramble')
+
+def insert_node(letter, parent_node_id)
+  @db.exec(
+    "SELECT findOrCreate('#{letter}', #{parent_node_id.nil? ? 'NULL' : parent_node_id})"
+  ).first["findorcreate"]
+end
+
+def save_word(node_id, word)
+  existing = @db.exec(
+    "SELECT word FROM nodes WHERE id = #{node_id}"
+  ).first["word"]
+
+  new_word = existing ? "#{existing},#{word}" : word
+  @db.exec(
+    "UPDATE nodes SET word = '#{new_word}' WHERE id = #{node_id}"
+  )
+end
+
+words = File.read("/usr/share/dict/words").split("\n")
+count = words.count
+words.each_with_index do |word, index|
+  print "   \r#{index + 1} / #{count}"
+
+  last_node_id = nil
+  word.chars.sort.each do |letter|
+    last_node_id = insert_node(letter, last_node_id)
+  end
+  save_word(last_node_id, word)
+end
+puts

--- a/languages/postgres/unscramble
+++ b/languages/postgres/unscramble
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+input="$1"
+psql -d unscramble -c "select unscramble('$input')" \
+  | head -n 3 | tail -n 1 \
+  | cut -b 2-100


### PR DESCRIPTION
Creates a tree structure in postgres where each node is a letter, and alphasorted words are stored as paths in the tree (letters know if they complete a word, and store their unscrambled words).

I've tried to write as much of this in postgres as I could. I use Ruby to loop through the dictionary and stock the database, but wrote a custom postgres function for taking a string and finding it's unscrambled words.

Upsides:
- lookups are very fast (see `CREATE FUNCTION unscramble`)
- returns all unscrambled options instead of just one

Downsides:
- converting the dictionary into a postgres backed tree takes ~18 minutes